### PR TITLE
Report and handle no-matching-stem wildcard pairs; add test for disjoint wildcard stems

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ CI runs automatically on every push and pull request using GitHub Actions (MSVC 
 To keep behavior explicit for maintainers and users, this project records intentional (or currently accepted) differences from Microsoft `fc.exe`:
 
 - **Wildcard matching**: Both file arguments support wildcards and match by file "stem"; error/warning reporting aligns to Windows behavior, but may differ for partial matches or ordering.
+  - If both wildcard sets expand successfully but no stem pairs match at all, CLI now reports: `FC: no matching stem pairs found for <pattern1> and <pattern2>` and exits non-zero.
 - **Output redirection**: Output is fully compatible with piping/redirection to files or CI environments, falling back to UTF-8 output if no console is present.
 - **`/OFF` and `/OFFLINE`**: Accepted as compatibility switches but currently act as no-ops in the CLI implementation.
 - **`/LBn`**: Implemented as a bounded resynchronization window heuristic in the LCS matcher, not as a strict legacy internal text-buffer emulation.

--- a/src/fc/fc.c
+++ b/src/fc/fc.c
@@ -662,6 +662,8 @@ WildcardFileCompare(
 
 	if (ContainsWildcard(Pattern1) && ContainsWildcard(Pattern2))
 	{
+		size_t ComparedPairCount = 0;
+
 		// Title-wild pairing: both sides are wildcards so match files by their
 		// base-name stem, e.g. "fc *.txt *.bak" pairs a.txt with a.bak.
 		BOOL* Used2 = (BOOL*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
@@ -752,6 +754,7 @@ WildcardFileCompare(
 			ConPrintW(hOut, L"\n\n");
 
 			FC_RESULT Result = FC_CompareFilesW(File1, File2, Config);
+			ComparedPairCount++;
 
 			switch (Result)
 			{
@@ -782,6 +785,18 @@ WildcardFileCompare(
 					OverallResult = -1;
 				break;
 			}
+		}
+
+		if (ComparedPairCount == 0)
+		{
+			HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+			ConPrintW(hOut, L"FC: no matching stem pairs found for ");
+			ConPrintW(hOut, Pattern1);
+			ConPrintW(hOut, L" and ");
+			ConPrintW(hOut, Pattern2);
+			ConPrintW(hOut, L"\n");
+			if (OverallResult == 0)
+				OverallResult = 1;
 		}
 
 		for (size_t m = 0; m < Exp2->Count; m++)

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -3,6 +3,8 @@
 // WideCharToMultiByte, ExitProcess
 #include <strsafe.h>     // StringCchLengthA/W, StringCchCopyW, StringCchCatW
 #include <pathcch.h>     // PathCchCombine, PathCchAddBackslash
+#include <string.h>      // strstr
+#include <stdlib.h>      // _wsystem
 #include "../fc/filecheck.h"   // FC_CONFIG, FC_RESULT, FC_OK, FC_DIFFERENT, FC_MODE_*, FC_IGNORE_*,
 // FileCheckCompareFilesUtf8()
 
@@ -1456,6 +1458,89 @@ static void Test_Regression_LBn_WindowLimitsMatch(const WCHAR* baseDir)
 	FreeTestPaths(&tp);
 }
 
+static BOOL ReadFileToBuffer(
+	_In_z_ const WCHAR* path,
+	_Out_writes_z_(outCap) char* outBuf,
+	_In_ DWORD outCap)
+{
+	HANDLE h = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (h == INVALID_HANDLE_VALUE)
+		return FALSE;
+
+	DWORD total = 0;
+	if (outCap > 0)
+		outBuf[0] = '\0';
+	while (outCap > 0 && total < outCap - 1)
+	{
+		DWORD bytesRead = 0;
+		char tmp[512];
+		if (!ReadFile(h, tmp, sizeof(tmp), &bytesRead, NULL) || bytesRead == 0)
+			break;
+		DWORD toCopy = bytesRead;
+		if (toCopy > outCap - 1 - total)
+			toCopy = outCap - 1 - total;
+		CopyMemory(outBuf + total, tmp, toCopy);
+		total += toCopy;
+	}
+	if (outCap > 0)
+		outBuf[total] = '\0';
+	CloseHandle(h);
+	return TRUE;
+}
+
+static void Test_Cli_DualWildcardDisjointStems(const WCHAR* baseDir)
+{
+	WCHAR dirLeft[MAX_LONG_PATH];
+	WCHAR dirRight[MAX_LONG_PATH];
+	if (FAILED(PathCchCombine(dirLeft, MAX_LONG_PATH, baseDir, L"wild_left"))) Throw(L"Combine fail", NULL);
+	if (FAILED(PathCchCombine(dirRight, MAX_LONG_PATH, baseDir, L"wild_right"))) Throw(L"Combine fail", NULL);
+	CreateDirectoryW(dirLeft, NULL);
+	CreateDirectoryW(dirRight, NULL);
+
+	WCHAR leftA[MAX_LONG_PATH];
+	WCHAR leftB[MAX_LONG_PATH];
+	WCHAR rightA[MAX_LONG_PATH];
+	WCHAR rightB[MAX_LONG_PATH];
+	ConcatPath(dirLeft, L"alpha.txt", leftA);
+	ConcatPath(dirLeft, L"beta.txt", leftB);
+	ConcatPath(dirRight, L"gamma.bak", rightA);
+	ConcatPath(dirRight, L"delta.bak", rightB);
+
+	WRITE_STR_FILE(leftA, "left alpha\n");
+	WRITE_STR_FILE(leftB, "left beta\n");
+	WRITE_STR_FILE(rightA, "right gamma\n");
+	WRITE_STR_FILE(rightB, "right delta\n");
+
+	WCHAR pattern1[MAX_LONG_PATH];
+	WCHAR pattern2[MAX_LONG_PATH];
+	WCHAR outputPath[MAX_LONG_PATH];
+	WCHAR modulePath[MAX_LONG_PATH];
+	WCHAR command[4096];
+
+	if (FAILED(PathCchCombine(pattern1, MAX_LONG_PATH, dirLeft, L"*.txt"))) Throw(L"Combine fail", NULL);
+	if (FAILED(PathCchCombine(pattern2, MAX_LONG_PATH, dirRight, L"*.bak"))) Throw(L"Combine fail", NULL);
+	if (FAILED(PathCchCombine(outputPath, MAX_LONG_PATH, baseDir, L"wildcard_disjoint_output.txt"))) Throw(L"Combine fail", NULL);
+	if (!GetModuleFileNameW(NULL, modulePath, MAX_LONG_PATH)) Throw(L"Module path fail", NULL);
+	WCHAR* lastSlash = wcsrchr(modulePath, L'\\');
+	if (lastSlash == NULL) Throw(L"Module path fail", NULL);
+	lastSlash[1] = L'\0';
+	if (FAILED(StringCchCatW(modulePath, MAX_LONG_PATH, L"fc.exe"))) Throw(L"Combine fail", NULL);
+
+	if (FAILED(StringCchPrintfW(command, ARRAYSIZE(command),
+		L"\"%s\" \"%s\" \"%s\" > \"%s\" 2>&1",
+		modulePath, pattern1, pattern2, outputPath)))
+	{
+		Throw(L"Command build fail", NULL);
+	}
+
+	int exitCode = _wsystem(command);
+	char output[8192];
+	ASSERT_TRUE(exitCode != -1);
+	ASSERT_TRUE(ReadFileToBuffer(outputPath, output, ARRAYSIZE(output)));
+	ASSERT_TRUE(exitCode != 0);
+	ASSERT_TRUE(strstr(output, "FC: no matching stem pairs found for ") != NULL);
+}
+
 int wmain(void)
 {
 	WCHAR tempDir[MAX_LONG_PATH]; DWORD len = GetTempPathW(MAX_LONG_PATH, tempDir);
@@ -1526,6 +1611,7 @@ int wmain(void)
 	Test_Regression_AutoDetect_NullByteIsBinary(testDir);
 	Test_Regression_AutoDetect_TextContent_IsText(testDir);
 	Test_Regression_LBn_WindowLimitsMatch(testDir);
+	Test_Cli_DualWildcardDisjointStems(testDir);
 
 	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 	WriteW(hConsole, L"\n\n");

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1546,6 +1546,61 @@ static void Test_Cli_DualWildcardDisjointStems(const WCHAR* baseDir)
 	ASSERT_TRUE(strstr(output, "FC: no matching stem pairs found for ") != NULL);
 }
 
+static void Test_Cli_DualWildcardPartialStemOverlap(const WCHAR* baseDir)
+{
+	WCHAR dirLeft[MAX_LONG_PATH];
+	WCHAR dirRight[MAX_LONG_PATH];
+	if (FAILED(PathCchCombine(dirLeft, MAX_LONG_PATH, baseDir, L"wild_left_partial"))) Throw(L"Combine fail", NULL);
+	if (FAILED(PathCchCombine(dirRight, MAX_LONG_PATH, baseDir, L"wild_right_partial"))) Throw(L"Combine fail", NULL);
+	CreateDirectoryW(dirLeft, NULL);
+	CreateDirectoryW(dirRight, NULL);
+
+	WCHAR leftA[MAX_LONG_PATH];
+	WCHAR leftB[MAX_LONG_PATH];
+	WCHAR rightA[MAX_LONG_PATH];
+	WCHAR rightB[MAX_LONG_PATH];
+	ConcatPath(dirLeft, L"alpha.txt", leftA);
+	ConcatPath(dirLeft, L"beta.txt", leftB);
+	ConcatPath(dirRight, L"alpha.bak", rightA);
+	ConcatPath(dirRight, L"gamma.bak", rightB);
+
+	// One matching stem pair ("alpha"), one unmatched file on each side.
+	WRITE_STR_FILE(leftA, "shared content\n");
+	WRITE_STR_FILE(rightA, "shared content\n");
+	WRITE_STR_FILE(leftB, "left only\n");
+	WRITE_STR_FILE(rightB, "right only\n");
+
+	WCHAR pattern1[MAX_LONG_PATH];
+	WCHAR pattern2[MAX_LONG_PATH];
+	WCHAR outputPath[MAX_LONG_PATH];
+	WCHAR modulePath[MAX_LONG_PATH];
+	WCHAR command[4096];
+
+	if (FAILED(PathCchCombine(pattern1, MAX_LONG_PATH, dirLeft, L"*.txt"))) Throw(L"Combine fail", NULL);
+	if (FAILED(PathCchCombine(pattern2, MAX_LONG_PATH, dirRight, L"*.bak"))) Throw(L"Combine fail", NULL);
+	if (FAILED(PathCchCombine(outputPath, MAX_LONG_PATH, baseDir, L"wildcard_partial_output.txt"))) Throw(L"Combine fail", NULL);
+	if (!GetModuleFileNameW(NULL, modulePath, MAX_LONG_PATH)) Throw(L"Module path fail", NULL);
+	WCHAR* lastSlash = wcsrchr(modulePath, L'\\');
+	if (lastSlash == NULL) Throw(L"Module path fail", NULL);
+	lastSlash[1] = L'\0';
+	if (FAILED(StringCchCatW(modulePath, MAX_LONG_PATH, L"fc.exe"))) Throw(L"Combine fail", NULL);
+
+	if (FAILED(StringCchPrintfW(command, ARRAYSIZE(command),
+		L"\"%s\" \"%s\" \"%s\" > \"%s\" 2>&1",
+		modulePath, pattern1, pattern2, outputPath)))
+	{
+		Throw(L"Command build fail", NULL);
+	}
+
+	int exitCode = _wsystem(command);
+	char output[8192];
+	ASSERT_TRUE(exitCode != -1);
+	ASSERT_TRUE(ReadFileToBuffer(outputPath, output, ARRAYSIZE(output)));
+	ASSERT_TRUE(exitCode == 0);
+	ASSERT_TRUE(strstr(output, "Comparing files ") != NULL);
+	ASSERT_TRUE(strstr(output, "FC: no matching stem pairs found for ") == NULL);
+}
+
 int wmain(void)
 {
 	WCHAR tempDir[MAX_LONG_PATH]; DWORD len = GetTempPathW(MAX_LONG_PATH, tempDir);
@@ -1617,6 +1672,7 @@ int wmain(void)
 	Test_Regression_AutoDetect_TextContent_IsText(testDir);
 	Test_Regression_LBn_WindowLimitsMatch(testDir);
 	Test_Cli_DualWildcardDisjointStems(testDir);
+	Test_Cli_DualWildcardPartialStemOverlap(testDir);
 
 	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 	WriteW(hConsole, L"\n\n");

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1474,7 +1474,12 @@ static BOOL ReadFileToBuffer(
 	{
 		DWORD bytesRead = 0;
 		char tmp[512];
-		if (!ReadFile(h, tmp, sizeof(tmp), &bytesRead, NULL) || bytesRead == 0)
+		if (!ReadFile(h, tmp, sizeof(tmp), &bytesRead, NULL))
+		{
+			CloseHandle(h);
+			return FALSE;
+		}
+		if (bytesRead == 0)
 			break;
 		DWORD toCopy = bytesRead;
 		if (toCopy > outCap - 1 - total)

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -4,7 +4,6 @@
 #include <strsafe.h>     // StringCchLengthA/W, StringCchCopyW, StringCchCatW
 #include <pathcch.h>     // PathCchCombine, PathCchAddBackslash
 #include <string.h>      // strstr
-#include <stdlib.h>      // _wsystem
 #include "../fc/filecheck.h"   // FC_CONFIG, FC_RESULT, FC_OK, FC_DIFFERENT, FC_MODE_*, FC_IGNORE_*,
 // FileCheckCompareFilesUtf8()
 
@@ -1493,6 +1492,91 @@ static BOOL ReadFileToBuffer(
 	return TRUE;
 }
 
+static BOOL ResolveFcExePath(_Out_writes_z_(MAX_LONG_PATH) WCHAR* fcPath)
+{
+	if (!GetModuleFileNameW(NULL, fcPath, MAX_LONG_PATH))
+		return FALSE;
+
+	WCHAR* lastSlash = wcsrchr(fcPath, L'\\');
+	if (lastSlash == NULL)
+		return FALSE;
+	lastSlash[1] = L'\0';
+	if (FAILED(StringCchCatW(fcPath, MAX_LONG_PATH, L"fc.exe")))
+		return FALSE;
+	if (GetFileAttributesW(fcPath) != INVALID_FILE_ATTRIBUTES)
+		return TRUE;
+
+	WCHAR cwd[MAX_LONG_PATH];
+	if (!GetCurrentDirectoryW(MAX_LONG_PATH, cwd))
+		return FALSE;
+
+	if (FAILED(PathCchCombine(fcPath, MAX_LONG_PATH, cwd, L"src\\x64\\Release\\fc.exe")))
+		return FALSE;
+	if (GetFileAttributesW(fcPath) != INVALID_FILE_ATTRIBUTES)
+		return TRUE;
+
+	if (FAILED(PathCchCombine(fcPath, MAX_LONG_PATH, cwd, L"x64\\Release\\fc.exe")))
+		return FALSE;
+	return GetFileAttributesW(fcPath) != INVALID_FILE_ATTRIBUTES;
+}
+
+static BOOL RunFcToOutputFile(
+	_In_z_ const WCHAR* pattern1,
+	_In_z_ const WCHAR* pattern2,
+	_In_z_ const WCHAR* outputPath,
+	_Out_ DWORD* exitCode)
+{
+	WCHAR fcPath[MAX_LONG_PATH];
+	if (!ResolveFcExePath(fcPath))
+		return FALSE;
+
+	WCHAR cmdLine[4096];
+	if (FAILED(StringCchPrintfW(cmdLine, ARRAYSIZE(cmdLine),
+		L"\"%s\" \"%s\" \"%s\"",
+		fcPath, pattern1, pattern2)))
+	{
+		return FALSE;
+	}
+
+	SECURITY_ATTRIBUTES sa = { 0 };
+	sa.nLength = sizeof(sa);
+	sa.bInheritHandle = TRUE;
+	HANDLE outFile = CreateFileW(outputPath, GENERIC_WRITE, FILE_SHARE_READ, &sa, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (outFile == INVALID_HANDLE_VALUE)
+		return FALSE;
+
+	STARTUPINFOW si = { 0 };
+	si.cb = sizeof(si);
+	si.dwFlags = STARTF_USESTDHANDLES;
+	si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+	si.hStdOutput = outFile;
+	si.hStdError = outFile;
+
+	PROCESS_INFORMATION pi = { 0 };
+	BOOL ok = CreateProcessW(
+		fcPath,
+		cmdLine,
+		NULL,
+		NULL,
+		TRUE,
+		0,
+		NULL,
+		NULL,
+		&si,
+		&pi);
+
+	CloseHandle(outFile);
+	if (!ok)
+		return FALSE;
+
+	WaitForSingleObject(pi.hProcess, INFINITE);
+	ok = GetExitCodeProcess(pi.hProcess, exitCode);
+
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	return ok;
+}
+
 static void Test_Cli_DualWildcardDisjointStems(const WCHAR* baseDir)
 {
 	WCHAR dirLeft[MAX_LONG_PATH];
@@ -1519,28 +1603,13 @@ static void Test_Cli_DualWildcardDisjointStems(const WCHAR* baseDir)
 	WCHAR pattern1[MAX_LONG_PATH];
 	WCHAR pattern2[MAX_LONG_PATH];
 	WCHAR outputPath[MAX_LONG_PATH];
-	WCHAR modulePath[MAX_LONG_PATH];
-	WCHAR command[4096];
 
 	if (FAILED(PathCchCombine(pattern1, MAX_LONG_PATH, dirLeft, L"*.txt"))) Throw(L"Combine fail", NULL);
 	if (FAILED(PathCchCombine(pattern2, MAX_LONG_PATH, dirRight, L"*.bak"))) Throw(L"Combine fail", NULL);
 	if (FAILED(PathCchCombine(outputPath, MAX_LONG_PATH, baseDir, L"wildcard_disjoint_output.txt"))) Throw(L"Combine fail", NULL);
-	if (!GetModuleFileNameW(NULL, modulePath, MAX_LONG_PATH)) Throw(L"Module path fail", NULL);
-	WCHAR* lastSlash = wcsrchr(modulePath, L'\\');
-	if (lastSlash == NULL) Throw(L"Module path fail", NULL);
-	lastSlash[1] = L'\0';
-	if (FAILED(StringCchCatW(modulePath, MAX_LONG_PATH, L"fc.exe"))) Throw(L"Combine fail", NULL);
-
-	if (FAILED(StringCchPrintfW(command, ARRAYSIZE(command),
-		L"\"%s\" \"%s\" \"%s\" > \"%s\" 2>&1",
-		modulePath, pattern1, pattern2, outputPath)))
-	{
-		Throw(L"Command build fail", NULL);
-	}
-
-	int exitCode = _wsystem(command);
+	DWORD exitCode = 0;
 	char output[8192];
-	ASSERT_TRUE(exitCode != -1);
+	ASSERT_TRUE(RunFcToOutputFile(pattern1, pattern2, outputPath, &exitCode));
 	ASSERT_TRUE(ReadFileToBuffer(outputPath, output, ARRAYSIZE(output)));
 	ASSERT_TRUE(exitCode != 0);
 	ASSERT_TRUE(strstr(output, "FC: no matching stem pairs found for ") != NULL);
@@ -1573,28 +1642,13 @@ static void Test_Cli_DualWildcardPartialStemOverlap(const WCHAR* baseDir)
 	WCHAR pattern1[MAX_LONG_PATH];
 	WCHAR pattern2[MAX_LONG_PATH];
 	WCHAR outputPath[MAX_LONG_PATH];
-	WCHAR modulePath[MAX_LONG_PATH];
-	WCHAR command[4096];
 
 	if (FAILED(PathCchCombine(pattern1, MAX_LONG_PATH, dirLeft, L"*.txt"))) Throw(L"Combine fail", NULL);
 	if (FAILED(PathCchCombine(pattern2, MAX_LONG_PATH, dirRight, L"*.bak"))) Throw(L"Combine fail", NULL);
 	if (FAILED(PathCchCombine(outputPath, MAX_LONG_PATH, baseDir, L"wildcard_partial_output.txt"))) Throw(L"Combine fail", NULL);
-	if (!GetModuleFileNameW(NULL, modulePath, MAX_LONG_PATH)) Throw(L"Module path fail", NULL);
-	WCHAR* lastSlash = wcsrchr(modulePath, L'\\');
-	if (lastSlash == NULL) Throw(L"Module path fail", NULL);
-	lastSlash[1] = L'\0';
-	if (FAILED(StringCchCatW(modulePath, MAX_LONG_PATH, L"fc.exe"))) Throw(L"Combine fail", NULL);
-
-	if (FAILED(StringCchPrintfW(command, ARRAYSIZE(command),
-		L"\"%s\" \"%s\" \"%s\" > \"%s\" 2>&1",
-		modulePath, pattern1, pattern2, outputPath)))
-	{
-		Throw(L"Command build fail", NULL);
-	}
-
-	int exitCode = _wsystem(command);
+	DWORD exitCode = 0;
 	char output[8192];
-	ASSERT_TRUE(exitCode != -1);
+	ASSERT_TRUE(RunFcToOutputFile(pattern1, pattern2, outputPath, &exitCode));
 	ASSERT_TRUE(ReadFileToBuffer(outputPath, output, ARRAYSIZE(output)));
 	ASSERT_TRUE(exitCode == 0);
 	ASSERT_TRUE(strstr(output, "Comparing files ") != NULL);


### PR DESCRIPTION
### Motivation

- Ensure the CLI `fc` command reports and fails when two wildcard patterns contain no matching filename stems, matching expected Windows-like behavior for title-wild pairing. 
- Add an automated test that exercises the dual-wildcard pairing path where stems are disjoint to prevent regressions.

### Description

- In `WildcardFileCompare` (`src/fc/fc.c`) introduce a `ComparedPairCount` counter and emit a diagnostic `FC: no matching stem pairs found for <pat1> and <pat2>` when no stem pairs were compared, and set the overall result to indicate differences when appropriate.
- Keep existing memory handling for `Used2` and precomputed `Stems2`, and increment `ComparedPairCount` after each successful comparison (`FC_CompareFilesW`) between matched stems.
- Add helper `ReadFileToBuffer` in `src/test/test.c` and include necessary headers (`string.h`, `stdlib.h`).
- Add a new test `Test_Cli_DualWildcardDisjointStems` that creates two directories with non-overlapping stems (`*.txt` vs `*.bak`), invokes the built `fc.exe` via `_wsystem`, captures its stdout/stderr to a file, and asserts that the process exits nonzero and the output contains the `FC: no matching stem pairs found for ` message. 
- Register the new test in `wmain` so it runs as part of the full test suite.

### Testing

- Ran the test runner (`wmain` test binary) which executes the full test suite including the new `Test_Cli_DualWildcardDisjointStems` test, and confirmed the suite completed successfully with the new test exercising the dual-wildcard code path. 
- The new test verifies the `fc` CLI returns a nonzero exit code and the expected diagnostic string is present in the command output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3bef01f1c8332b199c0658eeb7ea6)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dual-wildcard compares now report when no filename stems match and exit non-zero. Adds robust CLI tests for disjoint and partial-overlap wildcard sets, and documents the behavior.

- **Bug Fixes**
  - Track compared stem pairs in `WildcardFileCompare`; if none are compared, print "FC: no matching stem pairs found for <pattern1> and <pattern2>" and set a non-zero result.
  - Add CLI tests for disjoint and partial-overlap patterns; run `fc.exe` via `CreateProcessW` with stdout/stderr redirected for reliable output capture; harden `ReadFileToBuffer`; note the behavior in README.

<sup>Written for commit ffc1f9028823a5d4bf8d9ced87f56181f47610a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

